### PR TITLE
Add conditional NLG

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,9 @@
 repos:
 -   repo: https://github.com/ambv/black
-    rev: 22.6.0
+    rev: 20.8b1
     hooks:
     - id: black
-      language_version: python3.8
+      language_version: python3.7
 -   repo: https://gitlab.com/pycqa/flake8
     rev: 3.9.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,18 +1,18 @@
 repos:
--   repo: https://github.com/ambv/black
-    rev: 20.8b1
-    hooks:
-    - id: black
-      language_version: python3.7
--   repo: https://gitlab.com/pycqa/flake8
-    rev: 3.9.0
-    hooks:
-    - id: flake8
--   repo: local
-    hooks:
-    -   id: pytest
-        name: run tests
-        entry: pytest tests -vv
-        language: system
-        always_run: true
-        pass_filenames: false
+    - repo: https://github.com/ambv/black
+      rev: 22.6.0
+      hooks:
+          - id: black
+            language_version: python3.8
+    - repo: https://gitlab.com/pycqa/flake8
+      rev: 3.9.0
+      hooks:
+          - id: flake8
+    - repo: local
+      hooks:
+          - id: pytest
+            name: run tests
+            entry: pytest tests -vv
+            language: system
+            always_run: true
+            pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
       rev: 22.6.0
       hooks:
           - id: black
-            language_version: python3.8
+            language_version: python3.7
     - repo: https://gitlab.com/pycqa/flake8
       rev: 3.9.0
       hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,9 @@
 repos:
 -   repo: https://github.com/ambv/black
-    rev: 20.8b1
+    rev: 22.6.0
     hooks:
     - id: black
-      language_version: python3.7
+      language_version: python3.8
 -   repo: https://gitlab.com/pycqa/flake8
     rev: 3.9.0
     hooks:

--- a/dialoguekit/nlg/nlg.py
+++ b/dialoguekit/nlg/nlg.py
@@ -15,7 +15,7 @@ class NLG(AbstractNLG):
     def __init__(
         self, response_templates: Dict[Intent, List[AnnotatedUtterance]]
     ) -> None:
-        """Template based NLG.
+        """Template-based NLG.
 
         To use this NLG component, on of the template extraction methods from
         `template_from_traning_data.py` has to be used.

--- a/dialoguekit/nlg/nlg.py
+++ b/dialoguekit/nlg/nlg.py
@@ -1,59 +1,34 @@
 import json
 import random
 import sys
-from collections import defaultdict
 from copy import deepcopy
 from typing import Dict, List, Optional, Union
 
 from dialoguekit.core.annotated_utterance import AnnotatedUtterance
 from dialoguekit.core.annotation import Annotation
 from dialoguekit.core.intent import Intent
-from dialoguekit.nlg.template_from_training_data import (
-    build_template_from_instances,
-    extract_utterance_template,
-)
-from dialoguekit.nlu.models.satisfaction_classifier import (
-    SatisfactionClassifier,
-)
+from dialoguekit.nlg.nlg_abstract import AbstractNLG
 from dialoguekit.participant.participant import DialogueParticipant
 
 
-class NLG:
-    """Represents a Natural Language Generation (NLG) component."""
-
-    def __init__(self) -> None:
-        """Initializes the NLG component."""
-        self._response_templates: Dict[Intent, List[AnnotatedUtterance]] = None
-        self._GENERATED_SATISFACTION: bool = False
-
-    def template_from_file(
-        self,
-        template_file: str,
-        participant_to_learn: str = "USER",
-        satisfaction_classifier: Union[None, SatisfactionClassifier] = None,
+class NLG(AbstractNLG):
+    def __init__(
+        self, response_templates: Dict[Intent, List[AnnotatedUtterance]]
     ) -> None:
-        """Generates template from DialogueKit dialogue JSON format."""
-        self._response_templates = extract_utterance_template(
-            annotated_dialogue_file=template_file,
-            participant_to_learn=participant_to_learn,
-            satisfaction_classifier=satisfaction_classifier,
-        )
-        if satisfaction_classifier:
-            self._GENERATED_SATISFACTION = True
+        """Template based NLG.
 
-    def template_from_objects(
-        self, utterances: List[AnnotatedUtterance]
-    ) -> None:
-        """Generates template from instances."""
-        self._response_templates = build_template_from_instances(
-            utterances=utterances
-        )
+        To use this NLG component, on of the template extraction methods from
+        `template_from_traning_data.py` has to be used.
+
+        Args:
+            response_templates: response template for NLG.
+        """
+        self._response_templates = response_templates
 
     def generate_utterance_text(
         self,
         intent: Intent,
         annotations: Optional[Union[List[Annotation], None]] = None,
-        satisfaction: Optional[Union[float, None]] = None,
         force_annotation: Optional[bool] = False,
     ) -> Union[AnnotatedUtterance, bool]:
         """Turns a structured utterance into a textual one.
@@ -68,19 +43,14 @@ class NLG:
             2. Based on the list of 'annotations' only the possible responses,
                 are kept. e.g. Filter out responses that are not possible to
                 use are removed.
-            3. If 'satisfaction' is provided:
-                Filter to the closest responses that are possible, and select a
-                random one.
-            3. If 'satisfaction' is not provided:
-                Select a random one without looking at the satisfaction metric.
+            3. Select a random one.
 
         Args:
-            intent: The intent of the wanted Utterance
-            annotations: The wanted annotations in the response Utterance
-            satisfaction: Desired satisfaction score of the response.
+            intent: The intent of the wanted Utterance.
+            annotations: The wanted annotations in the response Utterance.
             force_annotation: if 'True' and 'annotations' are provided,
-                                responses without annotations will also be
-                                filtered out during step 2.
+              responses without annotations will also be filtered out during
+              step 2.
 
         Returns:
             Generated response utterance using templates.
@@ -113,13 +83,8 @@ class NLG:
         if len(templates) == 0:
             return False
 
-        if satisfaction is not None:
-            response_utterance = self._select_closest_to_satisfaction(
-                templates, satisfaction
-            )
-        else:
-            response_utterance = random.choice(templates)
-            response_utterance = deepcopy(response_utterance)
+        response_utterance = random.choice(templates)
+        response_utterance = deepcopy(response_utterance)
 
         # Clear out annotations
         response_utterance._annotations = []
@@ -187,34 +152,6 @@ class NLG:
                 if len(template.get_annotations()) > 0
             ]
         return filtered_annotated_utterances
-
-    def _select_closest_to_satisfaction(
-        self, templates: List[AnnotatedUtterance], satisfaction: int
-    ) -> AnnotatedUtterance:
-        """Find the closest annotated utterance based on satisfaction.
-
-        If there are multiple possible options a random one will be selected.
-
-        Args:
-            templates: AnnotatedUtterances with satisfaction metric.
-            satisfaction: The desired satisfaction score.
-
-        Returns:
-            AnnotatedUtterance that has the closest satisfaction score.
-        """
-        templates = sorted(
-            templates, key=lambda item: item.metadata.get("satisfaction")
-        )
-
-        distances = defaultdict(list)
-        for annotated_utterance in templates:
-            dist = abs(
-                annotated_utterance.metadata.get("satisfaction") - satisfaction
-            )
-            distances[dist].append(annotated_utterance)
-
-        lowest_distance = sorted(list(distances.keys()))[0]
-        return deepcopy(random.choice(distances[lowest_distance]))
 
     def get_intent_annotation_specifications(
         self,

--- a/dialoguekit/nlg/nlg_abstract.py
+++ b/dialoguekit/nlg/nlg_abstract.py
@@ -18,7 +18,10 @@ class AbstractNLG(ABC):
         annotations: Optional[Union[List[Annotation], None]] = None,
         force_annotation: bool = False,
     ) -> Union[AnnotatedUtterance, bool]:
-        """Generates an annotated utterance.
+        """Turns a structured utterance into a textual one.
+
+        This method is supposed to be implemented in a way that takes the
+        arguments and returns a textual utterance, based on the arguments.
 
         Args:
             intent: The underlying intent of the utterance.
@@ -30,5 +33,8 @@ class AbstractNLG(ABC):
         Returns:
             Generated response using templates.
             If generation fails, False should be returned.
+
+        Raises:
+            NotImplementedError: If not implemented in derived class.
         """
-        pass
+        raise NotImplementedError

--- a/dialoguekit/nlg/nlg_abstract.py
+++ b/dialoguekit/nlg/nlg_abstract.py
@@ -1,0 +1,96 @@
+"""Abstract interface for NLG."""
+
+from abc import ABC, abstractmethod
+from typing import Dict, List, Optional, Union
+
+from dialoguekit.core.annotated_utterance import AnnotatedUtterance
+from dialoguekit.core.annotation import Annotation
+from dialoguekit.core.intent import Intent
+
+
+class NLG(ABC):
+    def __init__(self) -> None:
+        """Represents a Natural Language Generation (NLG) component."""
+        self._response_templates: Dict[
+            Intent, List[AnnotatedUtterance]
+        ] = dict()
+        self._GENERATED_SATISFACTION: bool = False
+
+    @abstractmethod
+    def template_from_file(
+        self,
+        template_file: str,
+        participant_to_learn: str = "USER",
+    ) -> None:
+        """Generates template from DialogueKit JSON format.
+
+        Args:
+            template_file: Path to the template file containing annotated
+              dialogues.
+            participant_to_learn: Defines which participant from the dialogues
+              to consider utterances for.
+            satisfaction_classifier: TBD.
+        """
+        pass
+
+    @abstractmethod
+    def template_from_objects(
+        self,
+        utterances: List[AnnotatedUtterance],
+    ) -> None:
+        """Generates template from a list of annotated utterances.
+
+        Args:
+            utterances: A list of AnnotatedUtterance instances.
+        """
+        pass
+
+    @abstractmethod
+    def generate_utterance_text(
+        self,
+        intent: Intent,
+        annotations: Optional[Union[List[Annotation], None]] = None,
+        force_annotation: bool = False,
+    ) -> Union[AnnotatedUtterance, bool]:
+        """Textualizes a structured utterance using the templates.
+
+        Args:
+            intent: The underlying intent of the utterance.
+            annotations: If provided, these annotations should be included in
+              the utterance.
+            force_annotation: A flag to indicate whether annotations should be
+              forced or not.
+
+        Returns:
+            Generated response using templates.
+        """
+        pass
+
+    @abstractmethod
+    def dump_template(self, filepath: str) -> None:
+        """Dump template to JSON format.
+
+        Args:
+            filepath: Destination path for the resulting JSON file."""
+        pass
+
+    @abstractmethod
+    def _filter_templates(
+        self,
+        templates: List[AnnotatedUtterance],
+        annotations: List[Annotation],
+        force_annotation: bool,
+    ) -> List[AnnotatedUtterance]:
+        """Filters available templates based on annotations.
+
+        Args:
+            templates: Template annotated utterance.
+            annotations: List of annotations to be used for filtering.
+            force_annotation: If 'True' and annotations are provided templates
+              without annotations will also be filtered out.
+
+        Returns:
+            List of annotated utterances that are possible to create with the
+            provided annotations.
+        """
+        pass

--- a/dialoguekit/nlg/nlg_abstract.py
+++ b/dialoguekit/nlg/nlg_abstract.py
@@ -1,49 +1,15 @@
 """Abstract interface for NLG."""
 
 from abc import ABC, abstractmethod
-from typing import Dict, List, Optional, Union
+from typing import List, Optional, Union
 
 from dialoguekit.core.annotated_utterance import AnnotatedUtterance
 from dialoguekit.core.annotation import Annotation
 from dialoguekit.core.intent import Intent
 
 
-class NLG(ABC):
-    def __init__(self) -> None:
-        """Represents a Natural Language Generation (NLG) component."""
-        self._response_templates: Dict[
-            Intent, List[AnnotatedUtterance]
-        ] = dict()
-        self._GENERATED_SATISFACTION: bool = False
-
-    @abstractmethod
-    def template_from_file(
-        self,
-        template_file: str,
-        participant_to_learn: str = "USER",
-    ) -> None:
-        """Generates template from DialogueKit JSON format.
-
-        Args:
-            template_file: Path to the template file containing annotated
-              dialogues.
-            participant_to_learn: Defines which participant from the dialogues
-              to consider utterances for.
-            satisfaction_classifier: TBD.
-        """
-        pass
-
-    @abstractmethod
-    def template_from_objects(
-        self,
-        utterances: List[AnnotatedUtterance],
-    ) -> None:
-        """Generates template from a list of annotated utterances.
-
-        Args:
-            utterances: A list of AnnotatedUtterance instances.
-        """
-        pass
+class AbstractNLG(ABC):
+    """Represents a Natural Language Generation (NLG) component."""
 
     @abstractmethod
     def generate_utterance_text(
@@ -52,7 +18,7 @@ class NLG(ABC):
         annotations: Optional[Union[List[Annotation], None]] = None,
         force_annotation: bool = False,
     ) -> Union[AnnotatedUtterance, bool]:
-        """Textualizes a structured utterance using the templates.
+        """Generates an annotated utterance.
 
         Args:
             intent: The underlying intent of the utterance.
@@ -63,34 +29,6 @@ class NLG(ABC):
 
         Returns:
             Generated response using templates.
-        """
-        pass
-
-    @abstractmethod
-    def dump_template(self, filepath: str) -> None:
-        """Dump template to JSON format.
-
-        Args:
-            filepath: Destination path for the resulting JSON file."""
-        pass
-
-    @abstractmethod
-    def _filter_templates(
-        self,
-        templates: List[AnnotatedUtterance],
-        annotations: List[Annotation],
-        force_annotation: bool,
-    ) -> List[AnnotatedUtterance]:
-        """Filters available templates based on annotations.
-
-        Args:
-            templates: Template annotated utterance.
-            annotations: List of annotations to be used for filtering.
-            force_annotation: If 'True' and annotations are provided templates
-              without annotations will also be filtered out.
-
-        Returns:
-            List of annotated utterances that are possible to create with the
-            provided annotations.
+            If generation fails, False should be returned.
         """
         pass

--- a/dialoguekit/nlg/nlg_conditional.py
+++ b/dialoguekit/nlg/nlg_conditional.py
@@ -21,7 +21,6 @@ class ConditionalNLG(NLG):
         field and also a Number.
         """
         super().__init__(response_templates=response_templates)
-        self._GENERATED_SATISFACTION: bool = False
 
     def generate_utterance_text(
         self,
@@ -43,16 +42,17 @@ class ConditionalNLG(NLG):
             2. Based on the list of 'annotations' only the possible responses,
                 are kept. e.g. Filter out responses that are not possible to
                 use are removed.
-            3. If 'satisfaction' is provided:
-                Filter to the closest responses that are possible, and select a
-                random one.
-            3. If 'satisfaction' is not provided:
-                Select a random one without looking at the satisfaction metric.
+            3. If conditional is provided:
+                Filter to the closest responses that are possible to the
+                conditional_value, and select a random one.
+            3. If conditional is not provided:
+                Select a random one without looking at the conditional_value.
 
         Args:
             intent: The intent of the wanted Utterance
             annotations: The wanted annotations in the response Utterance
-            satisfaction: Desired satisfaction score of the response.
+            conditional: The desired metadata field to use as a conditional.
+            conditional_value: The desired conditional value score.
             force_annotation: if 'True' and 'annotations' are provided,
                                 responses without annotations will also be
                                 filtered out during step 2.
@@ -121,6 +121,7 @@ class ConditionalNLG(NLG):
 
         Args:
             templates: AnnotatedUtterances with conditional in the metadata
+            conditional: The desired metadata field to use as a conditional.
             conditional_value: The desired conditional value score.
 
         Returns:

--- a/dialoguekit/nlg/nlg_conditional.py
+++ b/dialoguekit/nlg/nlg_conditional.py
@@ -1,0 +1,142 @@
+import random
+from collections import defaultdict
+from copy import deepcopy
+from numbers import Number
+from typing import Dict, List, Optional, Union
+
+from dialoguekit.core.annotated_utterance import AnnotatedUtterance
+from dialoguekit.core.annotation import Annotation
+from dialoguekit.core.intent import Intent
+from dialoguekit.nlg.nlg import NLG
+from dialoguekit.participant.participant import DialogueParticipant
+
+
+class ConditionalNLG(NLG):
+    def __init__(
+        self, response_templates: Dict[Intent, List[AnnotatedUtterance]]
+    ) -> None:
+        """Template based NLG with support for conditional.
+
+        The conditional field has to be part of the AnnotatedUtterance metadata
+        field and also a Number.
+        """
+        super().__init__(response_templates=response_templates)
+        self._GENERATED_SATISFACTION: bool = False
+
+    def generate_utterance_text(
+        self,
+        intent: Intent,
+        annotations: Optional[Union[List[Annotation], None]] = None,
+        conditional: Optional[Union[str, None]] = None,
+        conditional_value: Optional[Union[Number, None]] = None,
+        force_annotation: Optional[bool] = False,
+    ) -> Union[AnnotatedUtterance, bool]:
+        """Turns a structured utterance into a textual one.
+
+        Note:
+        If the template does not contain the desired intent, a fallback will be
+        used. Stating "Sorry, I did not understand you." The response will have
+        the same 'intent'.
+
+        Generating a response is a multi-step process.
+            1. Responses to the desired 'intent' will be selected.
+            2. Based on the list of 'annotations' only the possible responses,
+                are kept. e.g. Filter out responses that are not possible to
+                use are removed.
+            3. If 'satisfaction' is provided:
+                Filter to the closest responses that are possible, and select a
+                random one.
+            3. If 'satisfaction' is not provided:
+                Select a random one without looking at the satisfaction metric.
+
+        Args:
+            intent: The intent of the wanted Utterance
+            annotations: The wanted annotations in the response Utterance
+            satisfaction: Desired satisfaction score of the response.
+            force_annotation: if 'True' and 'annotations' are provided,
+                                responses without annotations will also be
+                                filtered out during step 2.
+
+        Returns:
+            Generated response utterance using templates.
+            Note: if the filtering after step 1 and 2 does not find any response
+            that satisfies the criteria 'False' will be returned.
+        """
+        if self._response_templates is None:
+            raise ValueError(
+                "The template is not generated, use of of the\
+                template_from methods"
+            )
+        if annotations is None:
+            annotations = []
+
+        templates = self._response_templates.get(intent)
+
+        # If desired 'intent' is not in the template, use fallback.
+        if templates is None:
+            return AnnotatedUtterance(
+                intent=intent,
+                text="Sorry, I did not understand you.",
+                participant=DialogueParticipant.AGENT,
+            )
+        templates = self._filter_templates(
+            templates=templates,
+            annotations=annotations,
+            force_annotation=force_annotation,
+        )
+        # Check if filtering has filtered out everything
+        if len(templates) == 0:
+            return False
+
+        if conditional is not None:
+            response_utterance = self._select_closest_to_conditional(
+                templates=templates,
+                conditional=conditional,
+                conditional_value=conditional_value,
+            )
+        else:
+            response_utterance = random.choice(templates)
+            response_utterance = deepcopy(response_utterance)
+
+        # Clear out annotations
+        response_utterance._annotations = []
+
+        if annotations is not None:
+            for annotation in annotations:
+                response_utterance._text = response_utterance._text.replace(
+                    f"{{{annotation.slot}}}", annotation.value, 1
+                )
+                response_utterance.add_annotation(annotation)
+        return response_utterance
+
+    def _select_closest_to_conditional(
+        self,
+        templates: List[AnnotatedUtterance],
+        conditional: str,
+        conditional_value: Number,
+    ) -> AnnotatedUtterance:
+        """Find the closest annotated utterance based on conditional.
+
+        If there are multiple possible options a random one will be selected.
+
+        Args:
+            templates: AnnotatedUtterances with conditional in the metadata
+            conditional_value: The desired conditional value score.
+
+        Returns:
+            AnnotatedUtterance that has the closest conditional value.
+        """
+        templates = sorted(
+            templates, key=lambda item: item.metadata.get(conditional)
+        )
+
+        distances = defaultdict(list)
+        for annotated_utterance in templates:
+            dist = abs(
+                annotated_utterance.metadata.get(conditional)
+                - conditional_value
+            )
+            distances[dist].append(annotated_utterance)
+
+        lowest_distance = sorted(list(distances.keys()))[0]
+        return deepcopy(random.choice(distances[lowest_distance]))

--- a/dialoguekit/nlg/nlg_conditional.py
+++ b/dialoguekit/nlg/nlg_conditional.py
@@ -7,19 +7,15 @@ from typing import Dict, List, Optional, Union
 from dialoguekit.core.annotated_utterance import AnnotatedUtterance
 from dialoguekit.core.annotation import Annotation
 from dialoguekit.core.intent import Intent
-from dialoguekit.nlg.nlg import NLG
+from dialoguekit.nlg.nlg_template import TemplateNLG
 from dialoguekit.participant.participant import DialogueParticipant
 
 
-class ConditionalNLG(NLG):
+class ConditionalNLG(TemplateNLG):
     def __init__(
         self, response_templates: Dict[Intent, List[AnnotatedUtterance]]
     ) -> None:
-        """Template based NLG with support for conditional.
-
-        The conditional field has to be part of the AnnotatedUtterance metadata
-        field and also a Number.
-        """
+        """Template-based NLG with support for conditional."""
         super().__init__(response_templates=response_templates)
 
     def generate_utterance_text(
@@ -32,6 +28,9 @@ class ConditionalNLG(NLG):
     ) -> Union[AnnotatedUtterance, bool]:
         """Turns a structured utterance into a textual one.
 
+        The conditional field has to be part of the AnnotatedUtterance metadata
+        field and also a Number.
+
         Note:
         If the template does not contain the desired intent, a fallback will be
         used. Stating "Sorry, I did not understand you." The response will have
@@ -42,20 +41,20 @@ class ConditionalNLG(NLG):
             2. Based on the list of 'annotations' only the possible responses,
                 are kept. e.g. Filter out responses that are not possible to
                 use are removed.
-            3. If conditional is provided:
+            3. a) If conditional is provided:
                 Filter to the closest responses that are possible to the
                 conditional_value, and select a random one.
-            3. If conditional is not provided:
+            3. b) If conditional is not provided:
                 Select a random one without looking at the conditional_value.
 
         Args:
-            intent: The intent of the wanted Utterance
-            annotations: The wanted annotations in the response Utterance
+            intent: The intent of the wanted Utterance.
+            annotations: The wanted annotations in the response Utterance.
             conditional: The desired metadata field to use as a conditional.
             conditional_value: The desired conditional value score.
-            force_annotation: if 'True' and 'annotations' are provided,
-                                responses without annotations will also be
-                                filtered out during step 2.
+            force_annotation: If 'True' and 'annotations' are provided,
+              responses without annotations will also be filtered out during
+              step 2.
 
         Returns:
             Generated response utterance using templates.
@@ -115,7 +114,7 @@ class ConditionalNLG(NLG):
         conditional: str,
         conditional_value: Number,
     ) -> AnnotatedUtterance:
-        """Find the closest annotated utterance based on conditional.
+        """Finds the closest annotated utterance based on conditional.
 
         If there are multiple possible options a random one will be selected.
 

--- a/dialoguekit/nlg/nlg_template.py
+++ b/dialoguekit/nlg/nlg_template.py
@@ -11,17 +11,17 @@ from dialoguekit.nlg.nlg_abstract import AbstractNLG
 from dialoguekit.participant.participant import DialogueParticipant
 
 
-class NLG(AbstractNLG):
+class TemplateNLG(AbstractNLG):
     def __init__(
         self, response_templates: Dict[Intent, List[AnnotatedUtterance]]
     ) -> None:
         """Template-based NLG.
 
-        To use this NLG component, on of the template extraction methods from
-        `template_from_traning_data.py` has to be used.
+        To use this NLG component, one of the template extraction methods from
+        `template_from_training_data.py` has to be used.
 
         Args:
-            response_templates: response template for NLG.
+            response_templates: Response templates for NLG.
         """
         self._response_templates = response_templates
 

--- a/dialoguekit/nlg/template_from_training_data.py
+++ b/dialoguekit/nlg/template_from_training_data.py
@@ -62,7 +62,7 @@ def build_template_from_instances(
     return template
 
 
-def extract_utterance_template(
+def extract_utterance_template(  # noqa: C901
     annotated_dialogue_file: str,
     participant_to_learn: str = "USER",
     satisfaction_classifier: Optional[
@@ -102,14 +102,22 @@ def extract_utterance_template(
             satisfaction = None
             for utterance_record in dialog.get("conversation"):
                 participant = utterance_record.get("participant")
-                annotated_utterance = AnnotatedUtterance(
-                    text=utterance_record.get("utterance").strip(),
-                    intent=Intent(utterance_record.get("intent")),
-                    metadata={
-                        satisfaction: _DEFAULT_SATISFACTION
-                    },  # Satisfaction defaults to 3 (Normal)
-                    participant=DialogueParticipant.AGENT,
-                )
+
+                if satisfaction_classifier:
+                    annotated_utterance = AnnotatedUtterance(
+                        text=utterance_record.get("utterance").strip(),
+                        intent=Intent(utterance_record.get("intent")),
+                        metadata={
+                            "satisfaction": _DEFAULT_SATISFACTION
+                        },  # Satisfaction defaults to 3 (Normal)
+                        participant=DialogueParticipant.AGENT,
+                    )
+                else:
+                    annotated_utterance = AnnotatedUtterance(
+                        text=utterance_record.get("utterance").strip(),
+                        intent=Intent(utterance_record.get("intent")),
+                        participant=DialogueParticipant.AGENT,
+                    )
                 annotated_utterance_copy = copy.deepcopy(annotated_utterance)
 
                 # Only use the utterances from the wanted participant

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -13,6 +13,7 @@ DialogueKit is a framework for building and evaluating CIS systems.
    usage
    concepts
    nlu
+   nlg
    external_agents
    :ref:`modindex`
 

--- a/docs/source/nlg.rst
+++ b/docs/source/nlg.rst
@@ -41,3 +41,8 @@ The ConditionalNLG class adds two fields to the ``generate_utterance_text()`` me
 
 These fields are used to find the utterance that has the closest ``conditional_value`` to the utterance metadata field with the key ``conditional``.
 Note that this necessitates the need of a larger template with multiple values for the ``conditional``.
+
+Custom NLG
+""""""""""
+
+If you want to implement your own NLG component feel free to inherit from :py:class:`dialoguekit.nlg.nlg_abstract.AbstractNLG`.

--- a/docs/source/nlg.rst
+++ b/docs/source/nlg.rst
@@ -1,0 +1,43 @@
+Natural Language Generation (NLG)
+=================================
+
+The NLG components in Dialoguekit are template based.
+There are two different versions. :py:class:`dialoguekit.nlg.nlg.NLG` and :py:class:`dialoguekit.nlg.nlg_conditional.ConditionalNLG`. 
+
+These two are used in similar ways. The only difference is that the `ConditionalNLG` can use a conditional in the :py:attr:`dialoguekit.core.annotated_utterance.AnnotatedUtterance.metadata` as long as the conditionals value is a number.
+
+To start using these NLG classes a template needs to be generated. 
+Two methods for doing this are provided:
+
+    * :py:meth:`dialoguekit.nlg.template_from_training_data.build_template_from_instances`
+    * :py:meth:`dialoguekit.nlg.template_from_training_data.extract_utterance_template`
+
+Usage Example
+"""""""""""""
+
+.. code:: python
+
+    from dialoguekit.core.annotation import Annotation
+    from dialoguekit.core.intent import Intent
+    from dialoguekit.nlg.nlg import NLG
+    from dialoguekit.nlg.template_from_training_data import (
+        extract_utterance_template,
+    )
+
+    template = extract_utterance_template(
+        annotated_dialogue_file=ANNOTATED_DIALOGUE_FILE_PATH,
+    )
+    nlg = NLG(response_templates=template)
+    
+    response = nlg.generate_utterance_text(intent=Intent("COMPLETE"))
+
+ConditionalNLG
+""""""""""""""
+
+The ConditionalNLG class adds two fields to the ``generate_utterance_text()`` method. 
+
+  * ``conditional: str``
+  * ``conditional_value: Number``
+
+These fields are used to find the utterance that has the closest ``conditional_value`` to the utterance metadata field with the key ``conditional``.
+Note that this necessitates the need of a larger template with multiple values for the ``conditional``.

--- a/docs/source/nlg.rst
+++ b/docs/source/nlg.rst
@@ -1,8 +1,10 @@
 Natural Language Generation (NLG)
 =================================
 
-The NLG components in Dialoguekit are template based.
-There are two different versions. :py:class:`dialoguekit.nlg.nlg.NLG` and :py:class:`dialoguekit.nlg.nlg_conditional.ConditionalNLG`. 
+The NLG components in Dialoguekit are currently template-based.
+The basic template-based generation works by extracting templates from a set of training data. The templates are the user and agent utterances with the annotations removed. This version can be found here: :py:class:`dialoguekit.nlg.nlg_template.TemplateNLG`.
+
+An extended version of the basic template-based implementation which can perform conditional language generation is :py:class:`dialoguekit.nlg.nlg_conditional.ConditionalNLG`. Using a conditional may be useful in cases were other attributes then the intent and annotations may be of interest. Such as the users satisfaction. This can then be used to selecting templates that have a different tone based on the conditional, in this case the satisfaction score.
 
 These two are used in similar ways. The only difference is that the `ConditionalNLG` can use a conditional in the :py:attr:`dialoguekit.core.annotated_utterance.AnnotatedUtterance.metadata` as long as the conditional value is a number.
 
@@ -45,4 +47,4 @@ Note that this necessitates the need of a larger template with multiple values f
 Custom NLG
 """"""""""
 
-If you want to implement your own NLG component feel free to inherit from :py:class:`dialoguekit.nlg.nlg_abstract.AbstractNLG`.
+Any custom NLG component might be implemented by inheriting from :py:class:`dialoguekit.nlg.nlg_abstract.AbstractNLG`.

--- a/docs/source/nlg.rst
+++ b/docs/source/nlg.rst
@@ -4,7 +4,7 @@ Natural Language Generation (NLG)
 The NLG components in Dialoguekit are template based.
 There are two different versions. :py:class:`dialoguekit.nlg.nlg.NLG` and :py:class:`dialoguekit.nlg.nlg_conditional.ConditionalNLG`. 
 
-These two are used in similar ways. The only difference is that the `ConditionalNLG` can use a conditional in the :py:attr:`dialoguekit.core.annotated_utterance.AnnotatedUtterance.metadata` as long as the conditionals value is a number.
+These two are used in similar ways. The only difference is that the `ConditionalNLG` can use a conditional in the :py:attr:`dialoguekit.core.annotated_utterance.AnnotatedUtterance.metadata` as long as the conditional value is a number.
 
 To start using these NLG classes a template needs to be generated. 
 Two methods for doing this are provided:
@@ -34,7 +34,7 @@ Usage Example
 ConditionalNLG
 """"""""""""""
 
-The ConditionalNLG class adds two fields to the ``generate_utterance_text()`` method. 
+The ConditionalNLG class contains two additional parameters to the ``generate_utterance_text()`` method.
 
   * ``conditional: str``
   * ``conditional_value: Number``

--- a/tests/nlg/test_conditional_nlg.py
+++ b/tests/nlg/test_conditional_nlg.py
@@ -17,7 +17,7 @@ from dialoguekit.participant.participant import DialogueParticipant
 ANNOTATED_DIALOGUE_FILE = "tests/data/annotated_dialogues.json"
 
 
-# nlg class shared across tests.
+# NLG class shared across tests.
 @pytest.fixture
 def nlg_class() -> ConditionalNLG:
     template = extract_utterance_template(
@@ -61,9 +61,6 @@ def test_generate_utterance_text(nlg_class):
 
 
 def test_generate_utterance_text_force_annotation(nlg_class):
-    # A corner case where only one template found, i.e., REVEAL.EXPAND only has
-    # something like the {TITLE}.
-
     test = nlg_class.generate_utterance_text(
         Intent("COMPLETE"), annotations=None, force_annotation=True
     )
@@ -77,7 +74,7 @@ def test_generate_utterance_text_force_annotation(nlg_class):
     assert test.text == "TEST_DIRECTOR_NAME name"
 
 
-def test_none_annotations(nlg_class):
+def test_no_annotations(nlg_class):
     test = nlg_class.generate_utterance_text(Intent("COMPLETE"), None)
 
     assert test.intent == Intent("COMPLETE")

--- a/tests/nlg/test_template_from_training_data.py
+++ b/tests/nlg/test_template_from_training_data.py
@@ -195,19 +195,16 @@ def test_extract_utterance_template():
                 text="thank you",
                 intent=Intent(label="COMPLETE"),
                 participant=DialogueParticipant.AGENT,
-                metadata={None: 3},
             ),
             AnnotatedUtterance(
                 text="/exit",
                 intent=Intent(label="COMPLETE"),
                 participant=DialogueParticipant.AGENT,
-                metadata={None: 3},
             ),
             AnnotatedUtterance(
                 text="I would like to quit now.",
                 intent=Intent(label="COMPLETE"),
                 participant=DialogueParticipant.AGENT,
-                metadata={None: 3},
             ),
         ]
     )
@@ -217,7 +214,6 @@ def test_extract_utterance_template():
         intent=Intent(label="REVEAL.EXPAND"),
         annotations=[Annotation(slot="TITLE", value="")],
         participant=DialogueParticipant.AGENT,
-        metadata={None: 3},
     )
 
     assert templates.get(Intent("REVEAL.EXPAND")) == [test_annotation]

--- a/tests/nlg/test_template_nlg.py
+++ b/tests/nlg/test_template_nlg.py
@@ -5,7 +5,7 @@ import pytest
 from dialoguekit.core.annotated_utterance import AnnotatedUtterance
 from dialoguekit.core.annotation import Annotation
 from dialoguekit.core.intent import Intent
-from dialoguekit.nlg.nlg import NLG
+from dialoguekit.nlg.nlg_template import TemplateNLG
 from dialoguekit.nlg.template_from_training_data import (
     extract_utterance_template,
 )
@@ -16,11 +16,11 @@ ANNOTATED_DIALOGUE_FILE = "tests/data/annotated_dialogues.json"
 
 # nlg class shared across tests.
 @pytest.fixture
-def nlg_class() -> NLG:
+def nlg_class() -> TemplateNLG:
     template = extract_utterance_template(
         annotated_dialogue_file=ANNOTATED_DIALOGUE_FILE,
     )
-    nlg = NLG(response_templates=template)
+    nlg = TemplateNLG(response_templates=template)
     return nlg
 
 


### PR DESCRIPTION
Reworks how the NLG is structured.

There is now an abstract class for NLG. This class has only `generate_utterance_text()` as a requirement. All NLG implementations are supposed to be based off this class. This should allow for other non-template-based implementations.

The conditional implementation of the current `NLG` is moved to a subclass of NLG `ConditionalNLG`.

In addition to reworking the structure of NLG components the templating methods have been removed from the classes. Since the functions only used the methods from 
`template_from_training_data` without any modifications.


Closes: #122 