### PR TITLE
Make Annotation and SlotValueAnnotation dataclasses?

### DIFF
--- a/dialoguekit/core/annotation.py
+++ b/dialoguekit/core/annotation.py
@@ -1,37 +1,12 @@
 """Interface representing an annotation."""
 
 
+from dataclasses import dataclass, field
+
+
+@dataclass(eq=True, unsafe_hash=True)
 class Annotation:
-    def __init__(self, slot: str = None, value: str = None) -> None:
-        """Represents an annotation."""
-        self._slot = slot
-        self._value = value
+    """Represents an annotation."""
 
-    def __str__(self) -> str:
-        return f"Annotation({self._slot}, {self._value})"
-
-    def __repr__(self) -> str:
-        return f"Annotation({self._slot}, {self._value})"
-
-    def __hash__(self) -> int:
-        return hash((self._slot, self._value))
-
-    def __eq__(self, __o: object) -> bool:
-        """Comparison function."""
-        if not isinstance(__o, Annotation):
-            return False
-        if self._slot != __o._slot:
-            return False
-        elif self._value != __o._value:
-            return False
-        return True
-
-    @property
-    def slot(self) -> str:
-        """Returns the annotation slot."""
-        return self._slot
-
-    @property
-    def value(self) -> str:
-        """Returns the annotation value."""
-        return self._value
+    slot: str = field(default=None, hash=True)
+    value: str = field(default=None, hash=True)

--- a/dialoguekit/core/slot_value_annotation.py
+++ b/dialoguekit/core/slot_value_annotation.py
@@ -1,47 +1,16 @@
 """Interface representing slot-value annotations."""
 
 
-from typing import Text
+from dataclasses import dataclass, field
 
 from dialoguekit.core.annotation import Annotation
 
 
+@dataclass(eq=True, unsafe_hash=True)
 class SlotValueAnnotation(Annotation):
-    def __init__(
-        self,
-        slot: str = None,
-        value: str = None,
-        start: int = None,
-        end: int = None,
-    ) -> None:
-        """Represents slot-value annotation."""
-        # TODO Connect to Domain (and restrict to slots in there)?
-        super().__init__(slot=slot, value=value)
-        self._start = start
-        self._end = end
+    """Represents slot-value annotation."""
 
-    def __str__(self) -> Text:
-        return f"SlotValueAnnotation({self._slot}, {self._value}, \
-            {self._start}, {self._end})"
-
-    def __repr__(self) -> Text:
-        return f"SlotValueAnnotation({self._slot}, {self._value}, \
-            {self._start}, {self._end})"
-
-    def __hash__(self) -> int:
-        return hash((super().__hash__(), self._start, self._end))
-
-    def __eq__(self, __o: object) -> bool:
-        """Comparison function."""
-        if not isinstance(__o, SlotValueAnnotation):
-            return False
-        if self._slot != __o._slot:
-            return False
-        elif self._value != __o._value:
-            return False
-        elif self._start != __o._start:
-            return False
-        elif self._end != __o._end:
-            return False
-
-        return True
+    slot: str = field(default=None, hash=True)
+    value: str = field(default=None, hash=True)
+    start: int = field(default=None, hash=True)
+    end: int = field(default=None, hash=True)

--- a/dialoguekit/nlg/template_from_training_data.py
+++ b/dialoguekit/nlg/template_from_training_data.py
@@ -27,7 +27,7 @@ def _replace_slot_with_placeholder(
         annotated_utterance._text = annotated_utterance.text.replace(
             value, f"{{{placeholder_label}}}", 1
         )
-        annotation._value = ""
+        annotation.value = ""
 
 
 def build_template_from_instances(

--- a/dialoguekit/nlg/template_from_training_data.py
+++ b/dialoguekit/nlg/template_from_training_data.py
@@ -27,7 +27,7 @@ def _replace_slot_with_placeholder(
         annotated_utterance._text = annotated_utterance.text.replace(
             value, f"{{{placeholder_label}}}", 1
         )
-        annotation.value = ""
+        annotation.value = None
 
 
 def build_template_from_instances(

--- a/tests/core/test_slot_value_annotation.py
+++ b/tests/core/test_slot_value_annotation.py
@@ -1,5 +1,4 @@
 """Tests slot_value_annotation class."""
-import pytest
 from dialoguekit.core import SlotValueAnnotation
 
 
@@ -7,10 +6,10 @@ def test_initialization():
     """Tests object init."""
     a1 = SlotValueAnnotation(value="test1", slot="slot1", start=0, end=1)
     assert isinstance(a1, SlotValueAnnotation)
-    assert a1._value == "test1"
-    assert a1._slot == "slot1"
-    assert a1._start == 0
-    assert a1._end == 1
+    assert a1.value == "test1"
+    assert a1.slot == "slot1"
+    assert a1.start == 0
+    assert a1.end == 1
 
 
 def test_properties():
@@ -48,12 +47,3 @@ def test_comparison():
     a1 = SlotValueAnnotation(value="test1", slot="slot1", start=0, end=1)
     a2 = SlotValueAnnotation(value="test1", slot="slot1", start=0, end=2)
     assert a1 != a2
-
-
-def test_hash():
-    """Tests object hashing."""
-    a1 = SlotValueAnnotation(value="test1", slot="slot1", start=0, end=1)
-    try:
-        hash(a1)
-    except TypeError:
-        pytest.fail("SlotValueAnnotation hashing failed")

--- a/tests/nlg/test_template_from_training_data.py
+++ b/tests/nlg/test_template_from_training_data.py
@@ -210,7 +210,7 @@ def test_extract_utterance_template():
     test_annotation = AnnotatedUtterance(
         text="something like the {TITLE}",
         intent=Intent(label="REVEAL.EXPAND"),
-        annotations=[Annotation(slot="TITLE", value="")],
+        annotations=[Annotation(slot="TITLE")],
         participant=DialogueParticipant.AGENT,
     )
 


### PR DESCRIPTION
Make Annotation and SlotValueAnnotation dataclasses. `unsafe_hash` is needed for now as other `hash` methods need annotation hash.

Fixes #186