### PR TITLE
Add DialogueAct dataclass

### DIFF
--- a/dialoguekit/core/dialogue_act.py
+++ b/dialoguekit/core/dialogue_act.py
@@ -1,0 +1,17 @@
+"""Interface representing a dialogue act."""
+
+from ast import List
+from dataclasses import dataclass, field
+
+from dialoguekit.core.annotation import Annotation
+from dialoguekit.core.intent import Intent
+
+
+@dataclass(eq=True, unsafe_hash=True)
+class DialogueAct:
+    """Represents a dialogue act that is an intent and its annotations."""
+
+    intent: Intent = field(default=None, hash=True)
+    annotations: List[Annotation] = field(
+        default_factory=list, compare=True, hash=False
+    )

--- a/dialoguekit/core/dialogue_act.py
+++ b/dialoguekit/core/dialogue_act.py
@@ -1,4 +1,21 @@
-"""Interface representing a dialogue act."""
+"""Interface representing a dialogue act.
+
+For example in the following utterance, we have a dialogue act with an intent
+and its annotations regarding the search for a restaurant:
+
+>USER: I am looking for a cheap Turkish restaurant.
+DialogueAct(
+    intent = Intent("DISCLOSE"),
+    annotations = [Annotation(food="Turkish"), Annotation(price_range="cheap")],
+)
+
+In the following utterance, the dialogue act only has an intent:
+> USER: I like it.
+DialogueAct(
+    intent = Intent("DISCLOSE")
+    annotations = []
+)
+"""
 
 from dataclasses import dataclass, field
 from typing import List

--- a/dialoguekit/core/dialogue_act.py
+++ b/dialoguekit/core/dialogue_act.py
@@ -1,7 +1,7 @@
 """Interface representing a dialogue act."""
 
-from ast import List
 from dataclasses import dataclass, field
+from typing import List
 
 from dialoguekit.core.annotation import Annotation
 from dialoguekit.core.intent import Intent


### PR DESCRIPTION
Create a dataclass to represent a dialogue act. Upon approval, `AnnotatedUtterance` should be refactored to include a list of dialogue acts instead of an intent and annotations.

Part of #157